### PR TITLE
BFS implementation in python fixes

### DIFF
--- a/Graph Traversal/BFS/bfs.py
+++ b/Graph Traversal/BFS/bfs.py
@@ -1,13 +1,14 @@
 import collections
 def bfs(graph, root): 
-    visited, queue = set(), collections.deque([root])
-    visited.add(root)
+    visited, queue = [], collections.deque([root])
+    visited.append(root)
     while queue: 
         vertex = queue.popleft()
         for neighbour in graph[vertex]: 
             if neighbour not in visited: 
-                visited.add(neighbour) 
-                queue.append(neighbour) 
+                visited.append(neighbour) 
+                queue.append(neighbour)
+    return visited
 if __name__ == '__main__':
-    graph = {0: [1, 2], 1: [2], 2: [3], 3: [1,2]} 
-    breadth_first_search(graph, 0)
+    graph = {0: [1,3], 1: [2], 2: [3], 3: [1,2]} 
+    print bfs(graph, 0)


### PR DESCRIPTION
I changed the "breadth_first_search" call (an undefined method) to call the bfs method because otherwise it throws an error.
I modified the visited set to an array so that the order would be kept.
And also returned visited as the output of the bfs method, and printed it in the example.
